### PR TITLE
Handle pfsConfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-```
+```sh
 git clone https://github.com/monodera/pfs_blackout_design.git
 cd pfs_blackout_design
 python3 -m pip install -e .
@@ -10,36 +10,38 @@ python3 -m pip install -e .
 
 ## Usage
 
-```
+```sh
 $ pfs_blackout_design -h
-usage: pfs_blackout_design [-h] [--hex] [--file] [-d INDIR] [-o OUTDIR] pfs_design_identifier
+usage: pfs_blackout_design [-h] [--visit VISIT] [--hex] [--file] [-d INDIR] [-o OUTDIR] pfs_design_identifier
 
-A command-line script to generate pfsDesign files for each proposal in the input design file
+A command-line script to generate pfsDesign or pfsConfig files for each proposal in the input design or config file
 
 positional arguments:
   pfs_design_identifier
-                        Input pfsDesign ID (either hex or int (default)) or pfsDesign filename
+                        Input pfsDesign ID (either hex or int (default)) or pfsDesign/pfsConfig filename
 
 optional arguments:
   -h, --help            show this help message and exit
-  --hex                 Hex string pfsDesign ID
-  --file                File Input
+  --visit VISIT         Integer visit ID for pfsConfig (default: None)
+  --hex                 Flag for the hex string input
+  --file                Flag for the filename input
   -d INDIR, --indir INDIR
-                        Input Directory
+                        Input Directory (default: .)
   -o OUTDIR, --outdir OUTDIR
-                        Output directory
+                        Output directory (default: .)
 ```
 
 ### Example
 
 This example read a `pfsDesign` file with the `pfsDesignId` of `5734893949501672337` from the `./tmp/examples` directory and save `pfsDesign` files containing only the information on fibers with a relevant proposal ID and calibration fibers under `./tmp/examples`.
-```
-$ pfs_blackout_design 5734893949501672337 -d ./tmp/examples --o tmp/examples/
+
+```shell
+$ pfs_blackout_design 5734893949501672337 -d ./tmp/examples -o tmp/examples/
 ```
 
 The above command will generate the following files in `./tmp/examples`.
 
-```
+```text
 pfsDesign-0x4f966fa98c958b91_S22A-EN16.fits
 pfsDesign-0x4f966fa98c958b91_S23A-QN900.fits
 pfsDesign-0x4f966fa98c958b91_S23A-QN901.fits
@@ -47,23 +49,46 @@ pfsDesign-0x4f966fa98c958b91_S23A-QN902.fits
 pfsDesign-0x4f966fa98c958b91_S23A-QN903.fits
 ```
 
+You can work on a `pfsConfig` file by supplying a `visit` parameter as follows.
+
+```sh
+$ pfs_blackout_design 5734893949501672337 -d ./tmp/examples -o tmp/examples/ --visit 1
+```
+
+The above example reads `pfsConfig-0x4f966fa98c958b91-000001.fits` in the `./tmp/examples/` directory and outputs the following files.
+
+```text
+pfsConfig-0x4f966fa98c958b91-000001_S22A-EN16.fits
+pfsConfig-0x4f966fa98c958b91-000001_S23A-QN900.fits
+pfsConfig-0x4f966fa98c958b91-000001_S23A-QN901.fits
+pfsConfig-0x4f966fa98c958b91-000001_S23A-QN902.fits
+pfsConfig-0x4f966fa98c958b91-000001_S23A-QN903.fits
+```
+
 You can also tell the `pfsDesignId` by a hex string or filename. The following two commands are equivalent to the example above.
 
-```
+```sh
 # By a hex string
 $ pfs_blackout_design 0x4f966fa98c958b91 -d ./tmp/examples -o ./tmp/examples --hex
+$ pfs_blackout_design 0x4f966fa98c958b91 -d ./tmp/examples -o ./tmp/examples --hex --visit 1
 
 # By a filename
 $ pfs_blackout_design pfsDesign-0x4f966fa98c958b91.fits -d ./tmp/examples -o ./tmp/examples --file
+$ pfs_blackout_design pfsConfig-0x4f966fa98c958b91-000001.fits -d ./tmp/examples -o ./tmp/examples --file
 ```
 
 ## Call from a Python script
 
-The following example is equialent to the command-line client example shown above.
+The following example is equivalent to the command-line client example shown above.
 
 ```python
 from pfs_blackout_design import MaskedPfsDesign
 
-masked_pfs_design = MaskedPfsDesign("pfsDesign-0x4f966fa98c958b91.fits", indir="./tmp/examples/", outdir="./tmp/examples/", is_file=True)
+masked_pfs_design = MaskedPfsDesign(
+    "pfsDesign-0x4f966fa98c958b91.fits",
+    indir="./tmp/examples/",
+    outdir="./tmp/examples/",
+    is_file=True,
+)
 masked_pfs_design.do_all()
 ```

--- a/src/pfs_blackout_design/cli/blackout_design.py
+++ b/src/pfs_blackout_design/cli/blackout_design.py
@@ -7,16 +7,27 @@ from .. import MaskedPfsDesign
 
 def main():
     parser = argparse.ArgumentParser(
-        description="A command-line script to generate pfsDesign files for each proposal in the input design file"
+        description="A command-line script to generate pfsDesign or pfsConfig files for each proposal in the input design or config file"
     )
     parser.add_argument(
         "pfs_design_identifier",
-        help="Input pfsDesign ID (either hex or int (default)) or pfsDesign filename",
+        help="Input pfsDesign ID (either hex or int (default)) or pfsDesign/pfsConfig filename",
     )
-    parser.add_argument("--hex", action="store_true", help="Hex string pfsDesign ID")
-    parser.add_argument("--file", action="store_true", help="File Input")
-    parser.add_argument("-d", "--indir", default=".", help="Input Directory")
-    parser.add_argument("-o", "--outdir", default=".", help="Output directory")
+    parser.add_argument(
+        "--visit", type=int, help="Integer visit ID for pfsConfig (default: None)"
+    )
+    parser.add_argument(
+        "--hex", action="store_true", help="Flag for the hex string input"
+    )
+    parser.add_argument(
+        "--file", action="store_true", help="Flag for the filename input"
+    )
+    parser.add_argument(
+        "-d", "--indir", default=".", help="Input Directory (default: .)"
+    )
+    parser.add_argument(
+        "-o", "--outdir", default=".", help="Output directory (default: .)"
+    )
 
     args = parser.parse_args()
 
@@ -26,6 +37,7 @@ def main():
         outdir=args.outdir,
         is_hex=args.hex,
         is_file=args.file,
+        visit=args.visit,
     )
     masked_pfs_design.do_all()
 


### PR DESCRIPTION
In addition to a pfsDesign file, this commit enables the script to work with a pfsConfig file. When `visit` parameter is supplied for the cases of integer and hex string inputs or `W_VISIT` exists in the FITS header for a filename input, the script recognizes the input is a `pfsConfig` file.