### PR TITLE
set targetType of masked science objects as SCIENCE_MAKED

### DIFF
--- a/src/pfsconfig_redaction/utils.py
+++ b/src/pfsconfig_redaction/utils.py
@@ -151,6 +151,7 @@ def redact(
             "obCode": "masked",
             "pfiNominal": (np.nan, np.nan),
             "pfiCenter": (np.nan, np.nan),
+            "targetType": TargetType.SCIENCE_MASKED,
         }
 
     if flux_keys is None:


### PR DESCRIPTION
Set masked objects' targetType as `pfs.datamodel.TargetType.SCIENCE_MAKED`.