### PR TITLE
Do not require FRAMEID in the pfsConfig header

### DIFF
--- a/src/pfsconfig_redaction/utils.py
+++ b/src/pfsconfig_redaction/utils.py
@@ -135,11 +135,13 @@ def redact(
     if filter_val is None:
         filter_val = "none"
 
-    logger.info(f"Starting redaction of {pfs_config.header['FRAMEID']}")
+    # NOTE: FRAMEID is present in PFSF files ingested at the summit but not in
+    # pfsConfig files written by the DRP. It is used for logging only.
+    logger.info(f"Starting redaction of {pfs_config.header.get('FRAMEID', 'N/A')}")
     logger.info(f"  pfsDesignId: {pfs_config.pfsDesignId:#016x}")
     logger.info(f"  pfsDesignName: {pfs_config.designName}")
 
-    orig_proposal_id = pfs_config.header.get("PROP-ID")
+    orig_proposal_id = pfs_config.header.get("PROP-ID", "N/A")
     logger.info(f"  Original proposal ID: {orig_proposal_id}")
 
     n_fiber_science: int = np.sum(pfs_config.targetType == TargetType.SCIENCE)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -354,6 +355,32 @@ class TestEdgeCases:
         # Should handle NaN/inf values without crashing
         result = redact(mock_config)
         assert len(result) == 2
+
+    def test_header_without_optional_keywords(self, simple_mock_pfs_config):
+        """A header lacking FRAMEID/PROP-ID is still redactable.
+
+        pfsConfig files produced by the DRP carry neither keyword; only the PFSF
+        files ingested at the summit do. Both are valid inputs, and the keywords
+        are used for logging only.
+        """
+        simple_mock_pfs_config.header = {}
+
+        result = redact(simple_mock_pfs_config)
+
+        assert len(result) == 1
+        assert result[0].proposal_id == "S25A-TEST"
+
+    def test_missing_header_keywords_are_logged_as_na(
+        self, simple_mock_pfs_config, caplog
+    ):
+        """Absent header keywords are logged as "N/A", not as "None"."""
+        caplog.set_level(logging.INFO)
+        simple_mock_pfs_config.header = {}
+
+        redact(simple_mock_pfs_config)
+
+        assert "Starting redaction of N/A" in caplog.text
+        assert "Original proposal ID: N/A" in caplog.text
 
     def test_empty_filter_names(self):
         """Test handling of empty filter names."""


### PR DESCRIPTION
## Problem

`redact()` read `pfs_config.header['FRAMEID']` directly, so any pfsConfig without that keyword raised `KeyError` **before any redaction happened**.

pfsConfig files written by the DRP carry neither `FRAMEID` nor `PROP-ID`; only the PFSF files ingested at the summit do. The example file tracked in this repository, `tmp/examples/pfsConfig-0x4f966fa98c958b91-000001.fits`, is one of them.

Reproducer (before this change):

```console
$ python -c "from pfs.datamodel import PfsConfig; from pfsconfig_redaction import redact; \
    redact(PfsConfig.readFits('tmp/examples/pfsConfig-0x4f966fa98c958b91-000001.fits'))"
KeyError: "Keyword 'FRAMEID' not found."
```

## Fix

Both keywords are used for logging only, so read them with `.get()` and fall back to `"N/A"`, the sentinel already used elsewhere for an absent proposal. The adjacent `PROP-ID` line already used `.get()` but had no default and printed `None`; its output is now consistent.

## Tests

Added test-first (watched them fail, then fixed):

- `test_header_without_optional_keywords` — a header lacking `FRAMEID`/`PROP-ID` can still be redacted
- `test_missing_header_keywords_are_logged_as_na` — missing keywords are logged as `N/A`, not `None`

```console
$ uv run pytest -q
47 passed
$ uv run ruff check src tests && uv run ruff format --check src tests
All checks passed!
9 files already formatted
```

Verified against the real file:

```console
$ python -c "... redact(PfsConfig.readFits('tmp/examples/...fits'))"
INFO - Starting redaction of N/A
INFO -   Original proposal ID: N/A
OK: produced 5 redacted configs
```

## Note

This is the first of several fixes found in a full review of the repository. The remaining ones (fibers of an unhandled `targetType` passing through unmasked, the `patch` mask value being silently truncated, the tautological consistency check, and the real-data tests that always skip in CI) will follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)