### PR TITLE
Stop truncating mask values that exceed the column width

### DIFF
--- a/src/pfsconfig_redaction/utils.py
+++ b/src/pfsconfig_redaction/utils.py
@@ -34,6 +34,39 @@ class RedactedPfsConfigDataClass:
     pfs_config: PfsConfig
 
 
+def _widen_string_columns(
+    pfs_config: PfsConfig, dict_mask: dict[str, int | str | float | tuple]
+) -> None:
+    """
+    Widen the fixed-width string columns that cannot hold their mask value.
+
+    The string columns of a pfsConfig are fixed width, and the width comes from
+    the data: ``patch`` is written as ``3A`` because the values are like "1,1",
+    so it is read back as a ``<U3`` array. Assigning a longer string into such
+    an array truncates it silently, which would store "-1,-1" as "-1,". The
+    column is grown first so that the documented mask value survives; it is
+    written back out at whatever width it then needs.
+
+    Parameters
+    ----------
+    pfs_config : PfsConfig
+        The PfsConfig object to be modified in place.
+    dict_mask : dict
+        The mask values that are going to be assigned into the columns.
+    """
+    for key, value in dict_mask.items():
+        if not isinstance(value, str):
+            continue
+        array = getattr(pfs_config, key)
+        dtype = getattr(array, "dtype", None)
+        if dtype is None or dtype.kind != "U":
+            continue
+        width = dtype.itemsize // np.dtype("U1").itemsize
+        if len(value) > width:
+            logger.debug(f"  Widening {key} from U{width} to U{len(value)}")
+            setattr(pfs_config, key, array.astype(f"U{len(value)}"))
+
+
 def redact(
     pfs_config: PfsConfig,
     cat_id: int = 9000,
@@ -196,6 +229,11 @@ def redact(
 
         # Create a copy of the original PfsConfig to redact
         redacted_cfg = copy.deepcopy(pfs_config)
+
+        # NOTE: do this before any assignment, otherwise numpy truncates the mask
+        # values to the width the column happened to have in the input file.
+        _widen_string_columns(redacted_cfg, dict_mask_science)
+        _widen_string_columns(redacted_cfg, dict_mask_fluxstd)
 
         n_fiber_masked_science: int = 0
         n_fiber_masked_fluxstd: int = 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,12 +101,53 @@ class TestIntegration:
                 assert redacted_pfs.targetType[i] == TargetType.SCIENCE_MASKED
                 assert redacted_pfs.proposalId[i] == "masked"
                 assert redacted_pfs.obCode[i] == "masked"
+                assert redacted_pfs.patch[i] == "-1,-1"
                 assert redacted_pfs.catId[i] == 9000
                 assert redacted_pfs.objId[i] == -original.fiberId[i]
                 assert redacted_pfs.ra[i] == -99
                 assert redacted_pfs.dec[i] == -99
                 assert np.all(np.isnan(redacted_pfs.fiberFlux[i]))
                 assert all(name == "none" for name in redacted_pfs.filterNames[i])
+
+    def test_mask_value_wider_than_the_column_is_not_truncated(self, drp_pfs_config):
+        """A mask value longer than the FITS column survives intact.
+
+        The string columns of a pfsConfig are fixed width (patch is 3A, so the
+        numpy array is <U3), and assigning a longer value into such an array
+        truncates it without warning: "-1,-1" would be stored as "-1,". The
+        redacted file has to carry the documented mask value instead.
+        """
+        original = drp_pfs_config
+        long_ob_code = "x" * 60  # obCode is 45A in a real file
+
+        assert original.patch.dtype.itemsize // 4 < len("-1,-1")
+        assert original.obCode.dtype.itemsize // 4 < len(long_ob_code)
+
+        redacted_configs = pfsconfig_redaction.redact(
+            original,
+            dict_mask_science={
+                "patch": "-1,-1",
+                "obCode": long_ob_code,
+                "targetType": TargetType.SCIENCE_MASKED,
+            },
+        )
+
+        for redacted_config in redacted_configs:
+            redacted_pfs = redacted_config.pfs_config
+            to_mask = science_fibers_of_other_proposals(
+                original, redacted_config.proposal_id
+            )
+
+            assert to_mask.size > 0, "the sample must contain fibers to mask"
+
+            for i in to_mask:
+                assert redacted_pfs.patch[i] == "-1,-1"
+                assert redacted_pfs.obCode[i] == long_ob_code
+
+            # Widening the column must leave every other fiber alone.
+            for i in np.flatnonzero(original.proposalId == "N/A"):
+                assert redacted_pfs.patch[i] == original.patch[i]
+                assert redacted_pfs.obCode[i] == original.obCode[i]
 
     def test_custom_masking_parameters(self, drp_pfs_config):
         """Test redaction with custom masking parameters."""


### PR DESCRIPTION
## Problem

The string columns of a pfsConfig are fixed width, and the width comes from the data. Real files write `patch` as `3A` because the values look like `"1,1"`, so it reads back as a `<U3` numpy array. Assigning the documented mask value `"-1,-1"` into that array **truncates it to `"-1,"` without any warning**, and the truncated value is written to the delivered file.

Before this change, on the sample committed in #32 (whose schema matches the real files) and on the DRP file in `tmp/examples/`:

```
input patch column: 3A
masked patch values after round-trip: ['-1,']
```

The [README](../blob/main/README.md) has always documented `-1,-1`, so files delivered so far carry a mask value that does not match the specification. `tract` is masked to `-1` at the same time, so the pair is not usable as a coordinate either way — the impact is that the delivered file disagrees with its own documentation, not that a target is identifiable.

The same trap applies to any mask value longer than the column it goes into. `"masked"` fits today because `obCode` is `45A` and `proposalId` is `10A` in the files seen so far, but a file whose every `obCode` is `"N/A"` writes a `3A` column, and `"masked"` would then be stored as `"mas"`.

## Fix

`_widen_string_columns()` grows the fixed-width string columns that cannot hold their mask value, before anything is assigned into them. The column is written back out at whatever width it then needs — `patch` becomes `5A` — which the datamodel handles, since it derives the FITS width from the values themselves.

It runs on the keys of `dict_mask_science` and `dict_mask_fluxstd`, so custom mask dictionaries get the same protection, and it only touches a column when the value does not fit.

## Tests

Test-first. RED:

```console
$ uv run pytest tests/test_integration.py -q
>               assert redacted_pfs.patch[i] == "-1,-1"
E               AssertionError: assert np.str_('-1,') == '-1,-1'
2 failed, 7 passed
```

- `test_redaction_masks_other_proposals` now asserts the documented `patch` mask value
- `test_mask_value_wider_than_the_column_is_not_truncated` covers the general case with a custom 60-character `obCode` mask, and checks that widening a column leaves every other fiber's value alone

GREEN:

```console
$ uv run pytest -q
49 passed
$ uv run ruff check src tests && uv run ruff format --check src tests
All checks passed!
10 files already formatted
```

End-to-end through FITS, on both the synthetic sample and the real DRP-produced example file:

```
=== PFSF01234500.fits | input patch column: 3A
   after round-trip: patch column 5A | masked patch values ['-1,-1']
   unmasked patch values kept: ['0,0' '1,1']
=== pfsConfig-0x4f966fa98c958b91-000001.fits | input patch column: 3A
   after round-trip: patch column 5A | masked patch values ['-1,-1']
   unmasked patch values kept: ['0,0' '1,1']
```

## Note

Delivered files produced before this change contain `"-1,"` in `patch` for masked fibers. If any of them need to match the documented format, they have to be regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)