### PR TITLE
Refuse to redact fibers no masking rule covers

### DIFF
--- a/src/pfsconfig_redaction/utils.py
+++ b/src/pfsconfig_redaction/utils.py
@@ -34,6 +34,29 @@ class RedactedPfsConfigDataClass:
     pfs_config: PfsConfig
 
 
+def _target_type_name(target_type: int) -> str:
+    """
+    Return a readable name for a targetType value.
+
+    Values the installed datamodel does not know about are reported as-is, since
+    they are exactly the ones an operator needs to see.
+
+    Parameters
+    ----------
+    target_type : int
+        The targetType value to describe.
+
+    Returns
+    -------
+    str
+        The name of the target type, or the raw value if it is unknown.
+    """
+    try:
+        return TargetType(target_type).name
+    except ValueError:
+        return f"unknown ({int(target_type)})"
+
+
 def _widen_string_columns(
     pfs_config: PfsConfig, dict_mask: dict[str, int | str | float | tuple]
 ) -> None:
@@ -278,6 +301,20 @@ def redact(
 
                 n_fiber_masked_fluxstd += 1
                 n_fiber_masked += 1
+            elif is_other_proposal:
+                # NOTE: only SCIENCE and FLUXSTD have a masking rule. Letting any
+                # other target type fall through would hand this fiber to the
+                # recipient with the proposalId, obCode, coordinates and objId of
+                # another proposal intact, so refuse to produce a file at all.
+                message = (
+                    f"Fiber {redacted_cfg.fiberId[i_fiber]} belongs to proposal "
+                    f"{redacted_cfg.proposalId[i_fiber]} and has targetType "
+                    f"{_target_type_name(redacted_cfg.targetType[i_fiber])}, for "
+                    "which no masking rule is defined. Refusing to redact for "
+                    f"proposal {propid_work}."
+                )
+                logger.error(f"  {message}")
+                raise ValueError(message)
             else:
                 # Count unmasked SCIENCE fibers belonging to current proposal
                 if (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -109,6 +109,42 @@ class TestIntegration:
                 assert np.all(np.isnan(redacted_pfs.fiberFlux[i]))
                 assert all(name == "none" for name in redacted_pfs.filterNames[i])
 
+    def test_unhandled_target_type_of_another_proposal_raises(self, drp_pfs_config):
+        """A fiber that no masking rule covers stops the redaction.
+
+        Only SCIENCE and FLUXSTD fibers have a rule. A fiber of another proposal
+        with any other targetType would otherwise be handed to the recipient with
+        its proposalId, obCode, coordinates and objId intact.
+        """
+        original = drp_pfs_config
+        i = np.flatnonzero(
+            (original.targetType == TargetType.SCIENCE) & (original.proposalId != "N/A")
+        )[0]
+        original.targetType[i] = TargetType.SUNSS_IMAGING
+
+        with pytest.raises(ValueError, match="targetType"):
+            pfsconfig_redaction.redact(original)
+
+    def test_unhandled_target_type_without_another_proposal_is_kept(
+        self, drp_pfs_config
+    ):
+        """The same fiber is fine when nobody else receives the file.
+
+        Fibers are only a problem when they have to be masked for someone, so a
+        file holding a single proposal is still redactable.
+        """
+        original = drp_pfs_config
+        only_proposal = original.proposalId[original.proposalId != "N/A"][0]
+        others = (original.proposalId != "N/A") & (original.proposalId != only_proposal)
+        original.proposalId[others] = only_proposal
+        i = np.flatnonzero(original.proposalId == only_proposal)[0]
+        original.targetType[i] = TargetType.SUNSS_IMAGING
+
+        results = pfsconfig_redaction.redact(original)
+
+        assert len(results) == 1
+        assert results[0].pfs_config.targetType[i] == TargetType.SUNSS_IMAGING
+
     def test_mask_value_wider_than_the_column_is_not_truncated(self, drp_pfs_config):
         """A mask value longer than the FITS column survives intact.
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -29,10 +29,16 @@ class TestPerformance:
         )
         mock_config.targetType = target_types
 
-        # Generate proposal IDs
+        # Generate proposal IDs. Only SCIENCE fibers and the flux standards that
+        # are also SCIENCE targets of a programme carry a proposal association;
+        # sky fibers are always "N/A".
         proposal_base = [f"S25A-{i:03d}QF" for i in range(1, n_proposals + 1)]
         proposal_base.append("N/A")
-        proposal_ids = np.random.choice(proposal_base, size=n_fibers)
+        proposal_ids = np.where(
+            target_types == TargetType.SKY,
+            "N/A",
+            np.random.choice(proposal_base, size=n_fibers),
+        )
         mock_config.proposalId = proposal_ids
 
         # Generate other required data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -314,15 +314,22 @@ class TestFluxstdRedaction:
         # the targetType. Turning the fiber into a SKY fiber would leave it as a
         # SKY fiber of another proposal, which redact() now refuses outright, and
         # the count check under test would never be reached.
-        corrupted_copy = copy.deepcopy(original)
-        corrupted_copy.proposalId = np.array(
+        corrupted_template = copy.deepcopy(original)
+        corrupted_template.proposalId = np.array(
             ["S26A-999QF", "N/A", "N/A", "S26A-888QF", "N/A", "S26A-888QF"],
             dtype="U10",
         )
 
+        # NOTE: redact() copies the config once per proposal, and the stand-in has
+        # to do the same. Handing out one shared object leaves the masking done
+        # for the first proposal in place while the second is processed, which
+        # makes the test depend on the order the proposals happen to come out in.
+        real_deepcopy = copy.deepcopy
+
         with (
             patch(
-                "pfsconfig_redaction.utils.copy.deepcopy", return_value=corrupted_copy
+                "pfsconfig_redaction.utils.copy.deepcopy",
+                side_effect=lambda _: real_deepcopy(corrupted_template),
             ),
             pytest.raises(ValueError, match="Number of FLUXSTD fibers"),
         ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,11 +95,8 @@ class TestRedactFunction:
 
         return mock_config
 
-    @patch("pfsconfig_redaction.utils.copy.deepcopy")
-    def test_redact_default_parameters(self, mock_deepcopy, mock_pfs_config):
+    def test_redact_default_parameters(self, mock_pfs_config):
         """Test redact function with default parameters."""
-        mock_deepcopy.return_value = mock_pfs_config
-
         result = redact(mock_pfs_config)
 
         assert isinstance(result, list)
@@ -180,17 +177,18 @@ class TestRedactFunction:
             if hasattr(mock_pfs_config, attr):
                 setattr(corrupted_copy, attr, getattr(mock_pfs_config, attr))
 
-        # Modify the corrupted copy to have a different targetType that creates mismatch
+        corrupted_copy.targetType = mock_pfs_config.targetType
+
+        # Modify the corrupted copy so that the counts no longer match.
         # Original: S25A-002QF has 1 SCIENCE fiber (position 1)
-        # Corrupted: S25A-002QF fiber becomes SKY, creating 0 unmasked SCIENCE fibers
-        corrupted_copy.targetType = np.array(
-            [
-                TargetType.SCIENCE,  # fiber 1: S25A-001QF
-                TargetType.SKY,  # fiber 2: S25A-002QF - Changed from SCIENCE
-                TargetType.SKY,  # fiber 3: N/A
-                TargetType.FLUXSTD,  # fiber 4: N/A
-                TargetType.SCIENCE,  # fiber 5: S25A-001QF
-            ]
+        # Corrupted: that fiber claims no proposal, so it is not counted as an
+        # unmasked SCIENCE fiber of S25A-002QF either.
+        # NOTE: the corruption drops the proposal association rather than changing
+        # the targetType. A SCIENCE fiber turned into a SKY fiber of another
+        # proposal is refused outright by redact(), and the count check under test
+        # would never be reached.
+        corrupted_copy.proposalId = np.array(
+            ["S25A-001QF", "N/A", "N/A", "N/A", "S25A-001QF"]
         )
 
         mock_deepcopy.return_value = corrupted_copy
@@ -312,16 +310,14 @@ class TestFluxstdRedaction:
 
         # Corrupt the working copy so the owner's duplicated FLUXSTD is no longer
         # counted as unmasked, while the SCIENCE counts stay consistent.
+        # NOTE: the corruption drops the proposal association rather than changing
+        # the targetType. Turning the fiber into a SKY fiber would leave it as a
+        # SKY fiber of another proposal, which redact() now refuses outright, and
+        # the count check under test would never be reached.
         corrupted_copy = copy.deepcopy(original)
-        corrupted_copy.targetType = np.array(
-            [
-                TargetType.SCIENCE,
-                TargetType.SKY,  # was FLUXSTD for S26A-999QF
-                TargetType.FLUXSTD,
-                TargetType.SCIENCE,
-                TargetType.SKY,
-                TargetType.FLUXSTD,
-            ]
+        corrupted_copy.proposalId = np.array(
+            ["S26A-999QF", "N/A", "N/A", "S26A-888QF", "N/A", "S26A-888QF"],
+            dtype="U10",
         )
 
         with (


### PR DESCRIPTION
## Problem

Only `SCIENCE` and `FLUXSTD` fibers of another proposal were masked. Any other `targetType` fell through to the `else` branch, which counts the fiber as unmasked and **leaves every field untouched**. The recipient received another programme's `proposalId`, `obCode`, coordinates and `objId` in full. The consistency check did not notice either — it only compares SCIENCE and FLUXSTD counts.

Reproduced on a real file by flipping a single SCIENCE fiber to `SUNSS_IMAGING`:

```
UNHANDLED targetType -> proposalId: S23A-QN901  ra: 334.658743515671
                        objId: 44768273782298140
                        obCode: r_44768273782298140_yabe_co_2023jul
```

This covers `UNASSIGNED`, `ENGINEERING`, `SUNSS_IMAGING`, `SUNSS_DIFFUSE`, `DCB`, `HOME`, `BLACKSPOT`, `AFL` — and every target type a future datamodel adds.

## Fix

Raise. The check sits next to the two masking branches and only fires where a leak would actually happen, i.e. for a fiber that must be masked for the proposal currently being processed:

```
ValueError: Fiber 21 belongs to proposal S23A-QN901 and has targetType
SUNSS_IMAGING, for which no masking rule is defined. Refusing to redact
for proposal S23A-QN900.
```

A file holding a single proposal still redacts, since nothing in it needs masking — the guard does not stop deliveries that were never at risk.

As discussed, this should almost never fire in practice: pfsConfig files are validated where they are written, and the fibers we receive only ever carry `SCIENCE`, `FLUXSTD` or `SKY`, with `SKY` never observed as a SCIENCE target. It is there for the day the datamodel grows a target type, so the decision goes to a human instead of into a delivered file. There is deliberately no option to switch it off.

## Tests

Test-first. RED:

```console
$ uv run pytest tests/test_integration.py -q
E       Failed: DID NOT RAISE ValueError
1 failed, 10 passed
```

- `test_unhandled_target_type_of_another_proposal_raises` — the leak case
- `test_unhandled_target_type_without_another_proposal_is_kept` — guards against over-reach: the same fiber is fine when nobody else receives the file. It passed before the fix and still passes, which is the point.

```console
$ uv run pytest -q
51 passed
$ uv run ruff check src tests && uv run ruff format --check src tests
All checks passed!
10 files already formatted
```

## Test fixtures that had to change

The guard made three existing tests fail, all of them because their fixtures produce fibers that cannot exist in a real file:

- **`test_performance.py`** assigned proposal IDs to fibers of every type, including `SKY`. Sky fibers never carry a proposal association.
- **`test_redact_fiber_count_validation`** and **`test_fluxstd_count_mismatch_raises`** corrupted the working copy by turning a fiber of *another* proposal into a `SKY` fiber. That is now refused before the count check under test is reached, so they drop the proposal association instead — which is what those checks are actually about.

Separately, `test_redact_default_parameters` no longer mocks `copy.deepcopy`. With the mock, the "copy" was the input itself, so the first proposal's masking was still in place when the second was processed, and a masked fiber (`proposalId` `"masked"`, `targetType` `SCIENCE_MASKED`) tripped the new guard. `deepcopy` works fine on a `Mock`, so nothing needed mocking. The remaining `deepcopy`-mocking tests are part of the next cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)