### PR TITLE
Return the redacted configs in a stable order

### DIFF
--- a/src/pfsconfig_redaction/utils.py
+++ b/src/pfsconfig_redaction/utils.py
@@ -213,10 +213,12 @@ def redact(
         logger.info("  No fibers found, returning empty list")
         return []
 
-    # Get unique proposal IDs only (not grouped by catId)
-    proposal_ids = list(set(pfs_config.proposalId))
-    # convert from np._str to str
-    proposal_ids = [str(s) for s in proposal_ids]
+    # Get unique proposal IDs only (not grouped by catId), as plain str rather
+    # than np.str_.
+    # NOTE: sorted, because iterating a set of strings yields an order that
+    # varies with PYTHONHASHSEED. Two runs over the same file would otherwise
+    # produce their outputs and their logs in a different order.
+    proposal_ids = sorted(str(s) for s in set(pfs_config.proposalId))
 
     logger.info(f"  Unique proposal IDs: {pformat(proposal_ids)}")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,6 +57,20 @@ class TestIntegration:
             {config.proposal_id for config in from_pfsf}
         )
 
+    def test_results_are_returned_in_a_stable_order(self, drp_pfs_config):
+        """The redacted configs come out sorted by proposal ID.
+
+        The order used to be whatever iterating a set of strings produced, which
+        varies with PYTHONHASHSEED: two runs over the same file could not be
+        compared, and an order-sensitive test failed on some interpreters only.
+        """
+        proposal_ids = [
+            config.proposal_id for config in pfsconfig_redaction.redact(drp_pfs_config)
+        ]
+
+        assert len(proposal_ids) > 1, "the sample must contain several proposals"
+        assert proposal_ids == sorted(proposal_ids)
+
     def test_redaction_preserves_non_science_targets(self, drp_pfs_config):
         """Test that SKY and FLUXSTD targets are preserved in all redacted configs."""
         redacted_configs = pfsconfig_redaction.redact(drp_pfs_config)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,12 +140,11 @@ class TestRedactFunction:
         assert isinstance(result, list)
         assert len(result) == 0  # No valid proposal IDs to process
 
-    @patch("pfsconfig_redaction.utils.copy.deepcopy")
-    def test_redact_fiber_count_validation(self, mock_deepcopy, mock_pfs_config):
+    def test_redact_fiber_count_validation(self, mock_pfs_config):
         """Test that fiber count validation works correctly."""
         # Create a corrupted copy where targetType gets modified during deepcopy
         # to simulate a scenario where counts don't match
-        corrupted_copy = Mock(spec=PfsConfig)
+        corrupted_template = Mock(spec=PfsConfig)
 
         # Copy all attributes from original
         for attr in [
@@ -175,9 +174,9 @@ class TestRedactFunction:
             "filterNames",
         ]:
             if hasattr(mock_pfs_config, attr):
-                setattr(corrupted_copy, attr, getattr(mock_pfs_config, attr))
+                setattr(corrupted_template, attr, getattr(mock_pfs_config, attr))
 
-        corrupted_copy.targetType = mock_pfs_config.targetType
+        corrupted_template.targetType = mock_pfs_config.targetType
 
         # Modify the corrupted copy so that the counts no longer match.
         # Original: S25A-002QF has 1 SCIENCE fiber (position 1)
@@ -187,13 +186,22 @@ class TestRedactFunction:
         # the targetType. A SCIENCE fiber turned into a SKY fiber of another
         # proposal is refused outright by redact(), and the count check under test
         # would never be reached.
-        corrupted_copy.proposalId = np.array(
+        corrupted_template.proposalId = np.array(
             ["S25A-001QF", "N/A", "N/A", "N/A", "S25A-001QF"]
         )
 
-        mock_deepcopy.return_value = corrupted_copy
+        # NOTE: redact() copies the config once per proposal, and the stand-in has
+        # to do the same. A shared object would carry the masking done for one
+        # proposal into the processing of the next.
+        real_deepcopy = copy.deepcopy
 
-        with pytest.raises(ValueError, match="Number of SCIENCE fibers"):
+        with (
+            patch(
+                "pfsconfig_redaction.utils.copy.deepcopy",
+                side_effect=lambda _: real_deepcopy(corrupted_template),
+            ),
+            pytest.raises(ValueError, match="Number of SCIENCE fibers"),
+        ):
             redact(mock_pfs_config)
 
     def test_redact_none_parameters(self, mock_pfs_config):


### PR DESCRIPTION
## Problem

`redact()` iterated `list(set(pfs_config.proposalId))`, so the proposals came out in whatever order a set of strings happened to yield — which varies with `PYTHONHASHSEED`, i.e. per process.

Consequences:

- two runs over the same file produce their outputs and their log lines in a different order, so runs cannot be compared;
- any order-sensitive test becomes a coin flip. This is what broke #34 in CI: the count-check test passed on Python 3.12 and failed on 3.11 and 3.13, and locally it flipped with the seed (`seed 0,1,5` fail / `2,3,4` pass). It looked like a version problem and was not.

## Fix

Sort the proposal IDs. On the example file the order is now identical whatever the seed:

```console
PYTHONHASHSEED=0 -> ['S22A-EN16', 'S23A-QN900', 'S23A-QN901', 'S23A-QN902', 'S23A-QN903']
PYTHONHASHSEED=1 -> ['S22A-EN16', 'S23A-QN900', 'S23A-QN901', 'S23A-QN902', 'S23A-QN903']
PYTHONHASHSEED=2 -> ['S22A-EN16', 'S23A-QN900', 'S23A-QN901', 'S23A-QN902', 'S23A-QN903']
```

## Tests

Test-first. `test_results_are_returned_in_a_stable_order` asserts the returned proposal IDs are sorted. RED — it fails on 5 of 6 seeds, passing only where the set order happens to already be sorted:

```console
seed=0: 1 failed   seed=3: 1 failed
seed=1: 1 failed   seed=4: 1 failed
seed=2: 1 failed   seed=5: 1 passed

E  AssertionError: assert ['S25B-003QF'... 'S25A-002QN'] == ['S25A-001QF'... 'S25B-003QF']
E    At index 0 diff: 'S25B-003QF' != 'S25A-001QF'
```

GREEN, across seeds:

```console
seed=0: 52 passed   seed=3: 52 passed
seed=1: 52 passed   seed=4: 52 passed
seed=2: 52 passed   seed=5: 52 passed
$ uv run ruff check src tests && uv run ruff format --check src tests
All checks passed!
10 files already formatted
```

`test_redact_fiber_count_validation` also stops handing out one shared object in place of `copy.deepcopy` — the same trap #34 hit in the FLUXSTD test. It is order-independent as written, but only because its corruption happens to leave nothing to mask; now it does not depend on that.

## Unrelated flake, reported for the record

During this work one full-suite run failed once and I could not attribute it: the run was captured with `tail -1`, so the test name was lost, and it did not recur in 17 subsequent full runs (including 6 more of `test_performance` alone). The likely suspects are the wall-clock thresholds in `test_performance.py` (`time_ratio < ...`, `coefficient_of_variation < 0.5`) and its unseeded `np.random` data, which is a known item on the review list, but this is a hypothesis and not a diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)