### PR TITLE
Replace the wall-clock assertions with deterministic ones

### DIFF
--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,5 +1,5 @@
-import time
-from unittest.mock import Mock
+import copy
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
@@ -8,11 +8,26 @@ from pfs.datamodel import PfsConfig, TargetType
 from pfsconfig_redaction.utils import redact
 
 
-class TestPerformance:
-    """Performance tests for the redaction functionality."""
+class TestLargeInputs:
+    """Tests of the redaction against inputs far larger than a real pfsConfig.
 
-    def create_large_mock_config(self, n_fibers=10000, n_proposals=50):
-        """Create a large mock PfsConfig for performance testing."""
+    NOTE: these deliberately assert no wall-clock time. Timing thresholds on a
+    shared CI runner measure the runner's load, not this code, and the ratios
+    they used to compare were dominated by noise because the baseline runs took
+    a few milliseconds. What is asserted instead are the properties that would
+    actually regress: the input is copied once per proposal rather than once per
+    fiber, the peak memory stays bounded, and the result does not change between
+    runs.
+    """
+
+    def create_large_mock_config(self, n_fibers=10000, n_proposals=50, seed=20250401):
+        """Create a large mock PfsConfig for testing.
+
+        NOTE: the data is generated from a fixed seed. With an unseeded
+        generator, every run exercised a different fiber table, so a failure
+        could not be reproduced from the test alone.
+        """
+        rng = np.random.default_rng(seed)
         mock_config = Mock(spec=PfsConfig)
         mock_config.header = {"FRAMEID": "PFSF99999999", "PROP-ID": "S25A-PERF"}
         mock_config.pfsDesignId = 0x99999999
@@ -22,7 +37,7 @@ class TestPerformance:
         mock_config.fiberId = np.arange(1, n_fibers + 1)
 
         # Mix of target types
-        target_types = np.random.choice(
+        target_types = rng.choice(
             [TargetType.SCIENCE, TargetType.SKY, TargetType.FLUXSTD],
             size=n_fibers,
             p=[0.7, 0.2, 0.1],
@@ -37,57 +52,57 @@ class TestPerformance:
         proposal_ids = np.where(
             target_types == TargetType.SKY,
             "N/A",
-            np.random.choice(proposal_base, size=n_fibers),
+            rng.choice(proposal_base, size=n_fibers),
         )
         mock_config.proposalId = proposal_ids
 
         # Generate other required data
-        mock_config.catId = np.random.randint(1000, 9999, size=n_fibers)
+        mock_config.catId = rng.integers(1000, 9999, size=n_fibers)
         mock_config.objId = np.arange(1, n_fibers + 1) * 10
 
         # Position and astronomical data
-        mock_config.tract = np.random.randint(1, 100, size=n_fibers)
+        mock_config.tract = rng.integers(1, 100, size=n_fibers)
         mock_config.patch = np.array(
             [
                 f"{i},{j}"
                 for i, j in zip(
-                    np.random.randint(1, 10, size=n_fibers),
-                    np.random.randint(1, 10, size=n_fibers),
+                    rng.integers(1, 10, size=n_fibers),
+                    rng.integers(1, 10, size=n_fibers),
                 )
             ]
         )
-        mock_config.ra = np.random.uniform(0, 360, size=n_fibers)
-        mock_config.dec = np.random.uniform(-90, 90, size=n_fibers)
-        mock_config.pmRa = np.random.normal(0, 10, size=n_fibers)
-        mock_config.pmDec = np.random.normal(0, 10, size=n_fibers)
-        mock_config.parallax = np.random.exponential(1e-6, size=n_fibers)
+        mock_config.ra = rng.uniform(0, 360, size=n_fibers)
+        mock_config.dec = rng.uniform(-90, 90, size=n_fibers)
+        mock_config.pmRa = rng.normal(0, 10, size=n_fibers)
+        mock_config.pmDec = rng.normal(0, 10, size=n_fibers)
+        mock_config.parallax = rng.exponential(1e-6, size=n_fibers)
         mock_config.obCode = np.array([f"code{i}" for i in range(n_fibers)])
         mock_config.pfiNominal = np.column_stack(
             [
-                np.random.uniform(-200, 200, size=n_fibers),
-                np.random.uniform(-200, 200, size=n_fibers),
+                rng.uniform(-200, 200, size=n_fibers),
+                rng.uniform(-200, 200, size=n_fibers),
             ]
         )
-        mock_config.pfiCenter = mock_config.pfiNominal + np.random.normal(
+        mock_config.pfiCenter = mock_config.pfiNominal + rng.normal(
             0, 0.1, size=(n_fibers, 2)
         )
 
         # Flux data (5 bands)
         n_bands = 5
-        mock_config.fiberFlux = np.random.exponential(1000, size=(n_fibers, n_bands))
-        mock_config.psfFlux = mock_config.fiberFlux * np.random.uniform(
+        mock_config.fiberFlux = rng.exponential(1000, size=(n_fibers, n_bands))
+        mock_config.psfFlux = mock_config.fiberFlux * rng.uniform(
             0.8, 1.2, size=(n_fibers, n_bands)
         )
-        mock_config.totalFlux = mock_config.fiberFlux * np.random.uniform(
+        mock_config.totalFlux = mock_config.fiberFlux * rng.uniform(
             1.0, 1.5, size=(n_fibers, n_bands)
         )
-        mock_config.fiberFluxErr = mock_config.fiberFlux * np.random.uniform(
+        mock_config.fiberFluxErr = mock_config.fiberFlux * rng.uniform(
             0.01, 0.1, size=(n_fibers, n_bands)
         )
-        mock_config.psfFluxErr = mock_config.psfFlux * np.random.uniform(
+        mock_config.psfFluxErr = mock_config.psfFlux * rng.uniform(
             0.01, 0.1, size=(n_fibers, n_bands)
         )
-        mock_config.totalFluxErr = mock_config.totalFlux * np.random.uniform(
+        mock_config.totalFluxErr = mock_config.totalFlux * rng.uniform(
             0.01, 0.1, size=(n_fibers, n_bands)
         )
 
@@ -98,33 +113,27 @@ class TestPerformance:
         return mock_config
 
     @pytest.mark.slow
-    def test_large_dataset_performance(self):
-        """Test redaction performance with a large dataset."""
+    def test_large_dataset_is_redacted_completely(self):
+        """A file far larger than a real one is redacted, with nothing left over."""
         n_fibers = 10000
         n_proposals = 50
 
         mock_config = self.create_large_mock_config(n_fibers, n_proposals)
+        expected_proposal_ids = {
+            str(pid) for pid in np.unique(mock_config.proposalId) if pid != "N/A"
+        }
 
-        start_time = time.time()
         result = redact(mock_config)
-        end_time = time.time()
 
-        execution_time = end_time - start_time
+        assert {item.proposal_id for item in result} == expected_proposal_ids
 
-        # Verify results
-        assert isinstance(result, list)
-        assert len(result) > 0
-
-        # Performance assertion - should complete within reasonable time
-        # Adjust threshold based on expected performance
-        assert execution_time < 30.0, (
-            f"Redaction took too long: {execution_time:.2f} seconds"
-        )
-
-        print(
-            f"Redacted {n_fibers} fibers with {n_proposals} proposals in {execution_time:.2f} seconds"
-        )
-        print(f"Generated {len(result)} redacted configurations")
+        for item in result:
+            others = np.flatnonzero(
+                (mock_config.proposalId != "N/A")
+                & (mock_config.proposalId != item.proposal_id)
+            )
+            assert others.size > 0
+            assert set(item.pfs_config.proposalId[others]) <= {"masked", "N/A"}
 
     @pytest.mark.slow
     def test_memory_usage_large_dataset(self):
@@ -154,99 +163,47 @@ class TestPerformance:
         print(f"Peak memory usage: {peak_mb:.2f} MB")
         print(f"Current memory usage: {current / 1024 / 1024:.2f} MB")
 
-    def test_scalability_with_proposal_count(self):
-        """Test how performance scales with number of proposals."""
-        n_fibers = 1000
-        proposal_counts = [5, 10, 25, 50]
-        execution_times = []
+    def test_input_is_copied_once_per_proposal(self):
+        """The work grows with the number of proposals, not with the fibers.
 
-        for n_proposals in proposal_counts:
-            mock_config = self.create_large_mock_config(n_fibers, n_proposals)
+        This replaces a pair of tests that compared wall-clock times as the
+        proposal and fiber counts grew. Copying the whole config inside the fiber
+        loop is the regression they were trying to catch, and counting the copies
+        catches it without measuring anything the runner controls.
+        """
+        mock_config = self.create_large_mock_config(n_fibers=1000, n_proposals=10)
+        real_deepcopy = copy.deepcopy
 
-            start_time = time.time()
+        with patch(
+            "pfsconfig_redaction.utils.copy.deepcopy", side_effect=real_deepcopy
+        ) as deepcopy_spy:
             result = redact(mock_config)
-            end_time = time.time()
 
-            execution_time = end_time - start_time
-            execution_times.append(execution_time)
+        assert len(result) > 1
+        assert deepcopy_spy.call_count == len(result)
 
-            assert isinstance(result, list)
-            # Number of results should be at most n_proposals (excluding N/A)
-            assert len(result) <= n_proposals
+    def test_repeated_execution_is_deterministic(self):
+        """Redacting the same input twice gives the same result.
 
-            print(
-                f"Proposals: {n_proposals}, Time: {execution_time:.3f}s, Results: {len(result)}"
+        This replaces a test that asserted the *duration* of repeated runs stayed
+        within a coefficient of variation, which measured the machine rather than
+        the code. Two runs agreeing also shows redact() leaves its input alone.
+        """
+        mock_config = self.create_large_mock_config(n_fibers=1000, n_proposals=10)
+
+        first = redact(mock_config)
+        second = redact(mock_config)
+
+        assert [item.proposal_id for item in first] == [
+            item.proposal_id for item in second
+        ]
+
+        for one, other in zip(first, second):
+            assert np.array_equal(
+                one.pfs_config.proposalId, other.pfs_config.proposalId
             )
-
-        # Check that execution time doesn't grow too dramatically
-        # (allowing for some variance due to system factors)
-        time_ratio = execution_times[-1] / execution_times[0]
-        proposal_ratio = proposal_counts[-1] / proposal_counts[0]
-
-        # Time should scale roughly linearly or better with proposal count
-        assert time_ratio < proposal_ratio * 2, (
-            f"Performance degraded too much: {time_ratio:.2f}x time for {proposal_ratio:.2f}x proposals"
-        )
-
-    def test_scalability_with_fiber_count(self):
-        """Test how performance scales with number of fibers."""
-        n_proposals = 10
-        fiber_counts = [100, 500, 1000, 2000]
-        execution_times = []
-
-        for n_fibers in fiber_counts:
-            mock_config = self.create_large_mock_config(n_fibers, n_proposals)
-
-            start_time = time.time()
-            result = redact(mock_config)
-            end_time = time.time()
-
-            execution_time = end_time - start_time
-            execution_times.append(execution_time)
-
-            assert isinstance(result, list)
-            assert len(result) <= n_proposals
-
-            print(
-                f"Fibers: {n_fibers}, Time: {execution_time:.3f}s, Results: {len(result)}"
+            assert np.array_equal(
+                one.pfs_config.targetType, other.pfs_config.targetType
             )
-
-        # Check scalability
-        time_ratio = execution_times[-1] / execution_times[0]
-        fiber_ratio = fiber_counts[-1] / fiber_counts[0]
-
-        # Time should scale roughly linearly with fiber count
-        assert time_ratio < fiber_ratio * 2, (
-            f"Performance degraded too much: {time_ratio:.2f}x time for {fiber_ratio:.2f}x fibers"
-        )
-
-    def test_repeated_execution_consistency(self):
-        """Test that repeated executions give consistent performance."""
-        n_fibers = 1000
-        n_proposals = 10
-        n_runs = 5
-
-        mock_config = self.create_large_mock_config(n_fibers, n_proposals)
-        execution_times = []
-
-        for run in range(n_runs):
-            start_time = time.time()
-            result = redact(mock_config)
-            end_time = time.time()
-
-            execution_time = end_time - start_time
-            execution_times.append(execution_time)
-
-            assert isinstance(result, list)
-
-        # Check consistency
-        mean_time = np.mean(execution_times)
-        std_time = np.std(execution_times)
-
-        print(f"Mean execution time: {mean_time:.3f}s ± {std_time:.3f}s")
-
-        # Standard deviation should be relatively small compared to mean
-        coefficient_of_variation = std_time / mean_time
-        assert coefficient_of_variation < 0.5, (
-            f"Execution time too variable: {coefficient_of_variation:.3f}"
-        )
+            assert np.array_equal(one.pfs_config.objId, other.pfs_config.objId)
+            assert np.array_equal(one.pfs_config.ra, other.pfs_config.ra)


### PR DESCRIPTION
## Problem

`test_performance.py` asserted on durations measured with `time.time()`:

| Assertion | Problem |
|---|---|
| `execution_time < 30.0` | measures the runner, not the code |
| `time_ratio < proposal_ratio * 2` | divides by a baseline run of a few milliseconds, so the ratio is mostly noise |
| `time_ratio < fiber_ratio * 2` | same |
| `coefficient_of_variation < 0.5` | measures machine load and first-run warm-up, and asserts nothing about the code |

A full-suite run failed once during #35 and could not be attributed — the test name was lost and it never recurred. These assertions are the most likely candidate, but **that was never confirmed**, so this PR is justified by what the assertions can and cannot tell us, not by a diagnosis.

The fixture also built its fiber table from an unseeded generator, so every run exercised different data and a failure could not be reproduced from the test alone.

## What this changes

The data is now generated from a fixed seed, and the timing assertions are replaced by properties that actually regress:

- **`test_input_is_copied_once_per_proposal`** — copying the config inside the fiber loop is the regression the two scalability tests were reaching for. Counting `copy.deepcopy` calls catches it without measuring anything the runner controls.
- **`test_repeated_execution_is_deterministic`** — what the coefficient-of-variation test was named after. Two runs agreeing also shows `redact()` leaves its input alone.
- **`test_large_dataset_is_redacted_completely`** — keeps the 10000-fiber input, but checks every proposal is accounted for and that no other proposal's association survives, instead of checking it finished within 30 s.

`test_memory_usage_large_dataset` keeps its `tracemalloc` assertion: it does not depend on timing.

The class is renamed `TestLargeInputs`, since nothing here measures performance any more. The file keeps its name to keep the diff reviewable.

## Verification

The copy-count assertion is exact — adding one extra copy per proposal fails it:

```console
E  AssertionError: assert 20 == 10
E   +  where 20 = <MagicMock name='deepcopy'>.call_count
```

```console
$ uv run pytest -q      # three consecutive runs
51 passed in 16.99s
51 passed in 17.01s
51 passed in 17.00s
$ uv run ruff check src tests && uv run ruff format --check src tests
All checks passed!
10 files already formatted
```

## What I could not show

I tried to demonstrate that the old timing tests would miss a regression the new ones catch, by removing the `deepcopy` entirely. That mutation is too destructive to discriminate: the old tests fail too, but through the count-mismatch `ValueError`, not through timing. So this PR does not claim the old assertions missed anything specific — only that they cannot reliably tell us anything, and that a flaky suite makes every other failure harder to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)