### PR TITLE
Check the redacted config instead of counting fibers

### DIFF
--- a/src/pfsconfig_redaction/utils.py
+++ b/src/pfsconfig_redaction/utils.py
@@ -90,6 +90,162 @@ def _widen_string_columns(
             setattr(pfs_config, key, array.astype(f"U{len(value)}"))
 
 
+def _equals_mask(actual: np.ndarray, mask_value) -> bool:
+    """
+    Check that every element of ``actual`` holds ``mask_value``.
+
+    NOTE: the comparison casts the mask value to the dtype it was stored in.
+    ``parallax`` is float32 in a real file, so the stored 1.0e-7 does not compare
+    equal to the Python float it came from.
+
+    Parameters
+    ----------
+    actual : numpy.ndarray
+        The values found in the redacted config.
+    mask_value : int, str, float or tuple
+        The value they are supposed to hold.
+
+    Returns
+    -------
+    bool
+        True if every element matches, NaN counting as a match for NaN.
+    """
+    expected = np.asarray(mask_value)
+    if expected.dtype.kind == "f" and actual.dtype.kind == "f":
+        expected = expected.astype(actual.dtype)
+        return bool(
+            np.all((actual == expected) | (np.isnan(actual) & np.isnan(expected)))
+        )
+    if expected.dtype.kind in "iu" and actual.dtype.kind in "iu":
+        expected = expected.astype(actual.dtype)
+    return bool(np.all(actual == expected))
+
+
+def _verify_redaction(
+    original: PfsConfig,
+    redacted: PfsConfig,
+    recipient: str,
+    dict_mask_science: dict,
+    dict_mask_fluxstd: dict,
+    flux_keys: list[str],
+    flux_val: float,
+    filter_val: str,
+) -> None:
+    """
+    Check the redacted config against the input before it is handed out.
+
+    The check is deliberately expressed against the *output*: which fibers had to
+    be masked is derived from the original config, and the redacted one is then
+    read back to confirm what actually happened to them. Restating the masking
+    rules would only assert that the loop did what the loop does.
+
+    Three things are verified:
+
+    1. every fiber that had to be masked holds the mask values, so a value that
+       failed to be stored (silently truncated, for instance) is caught;
+    2. no fiber of another proposal still shows its original ``proposalId`` or
+       ``obCode``, which holds whatever the mask values happen to be. A custom
+       mask dictionary that leaves either in place is refused;
+    3. the fibers that had to be left alone are untouched, so redaction cannot
+       quietly damage the recipient's own targets or the sky fibers.
+
+    Parameters
+    ----------
+    original : PfsConfig
+        The config as it was read.
+    redacted : PfsConfig
+        The redacted copy about to be returned.
+    recipient : str
+        The proposal ID this copy is destined for.
+    dict_mask_science, dict_mask_fluxstd : dict
+        The mask values that were applied.
+    flux_keys : list of str
+        The flux fields that were masked.
+    flux_val : float
+        The value the flux fields were masked with.
+    filter_val : str
+        The value the filter names were masked with.
+
+    Raises
+    ------
+    ValueError
+        If any of the three checks fails.
+    """
+    proposal_id = np.asarray(original.proposalId)
+    target_type = np.asarray(original.targetType)
+    is_other = (proposal_id != "N/A") & (proposal_id != recipient)
+
+    masked_science = np.flatnonzero(is_other & (target_type == TargetType.SCIENCE))
+    masked_fluxstd = np.flatnonzero(is_other & (target_type == TargetType.FLUXSTD))
+    untouched = np.flatnonzero(~is_other)
+
+    problems: list[str] = []
+
+    # 1. The mask values reached the config.
+    for indices, dict_mask in (
+        (masked_science, dict_mask_science),
+        (masked_fluxstd, dict_mask_fluxstd),
+    ):
+        if indices.size == 0:
+            continue
+        for key, value in dict_mask.items():
+            actual = np.asarray(getattr(redacted, key))[indices]
+            if not _equals_mask(actual, value):
+                problems.append(
+                    f"{key} was not masked with {value!r} on all "
+                    f"{indices.size} fibers that required it"
+                )
+
+    for i_fiber in masked_science:
+        for key in flux_keys:
+            if not _equals_mask(np.asarray(getattr(redacted, key)[i_fiber]), flux_val):
+                problems.append(f"{key} was not masked on fiber index {i_fiber}")
+        if any(name != filter_val for name in redacted.filterNames[i_fiber]):
+            problems.append(f"filterNames was not masked on fiber index {i_fiber}")
+
+    # 2. No proposal association of another programme survives.
+    # NOTE: a value that was already "N/A" identifies nothing, and masking it
+    # leaves it unchanged, so it is not a survival.
+    for indices in (masked_science, masked_fluxstd):
+        for key in ("proposalId", "obCode"):
+            before = np.asarray(getattr(original, key))[indices]
+            after = np.asarray(getattr(redacted, key))[indices]
+            still_there = np.flatnonzero((after == before) & (before != "N/A"))
+            if still_there.size > 0:
+                problems.append(
+                    f"{key} of another proposal survived on "
+                    f"{still_there.size} fibers, e.g. fiber index "
+                    f"{indices[still_there[0]]}"
+                )
+
+    # 3. Everything that had to be left alone was left alone.
+    keys_touched = set(dict_mask_science) | set(dict_mask_fluxstd) | {"objId"}
+    for key in sorted(keys_touched):
+        before = np.asarray(getattr(original, key))[untouched]
+        after = np.asarray(getattr(redacted, key))[untouched]
+        # NOTE: equal_nan, because a NaN that was there before is not a change.
+        # Real files carry NaN in the photometry of targets never measured.
+        if not np.array_equal(before, after, equal_nan=before.dtype.kind == "f"):
+            problems.append(f"{key} was modified on fibers that had to be left alone")
+
+    for i_fiber in untouched:
+        for key in flux_keys:
+            before = np.asarray(getattr(original, key)[i_fiber])
+            after = np.asarray(getattr(redacted, key)[i_fiber])
+            if not np.array_equal(before, after, equal_nan=before.dtype.kind == "f"):
+                problems.append(f"{key} was modified on fiber index {i_fiber}")
+        if list(original.filterNames[i_fiber]) != list(redacted.filterNames[i_fiber]):
+            problems.append(f"filterNames was modified on fiber index {i_fiber}")
+
+    if problems:
+        message = (
+            f"Redaction for proposal {recipient} did not produce a deliverable "
+            f"config: {'; '.join(sorted(set(problems)))}."
+        )
+        logger.error(f"  {message}")
+        raise ValueError(message)
+
+
 def redact(
     pfs_config: PfsConfig,
     cat_id: int = 9000,
@@ -355,23 +511,20 @@ def redact(
             f"  Number of unmasked fibers for {propid_work}: {n_fiber_unmasked}"
         )
 
-        # NOTE: check SCIENCE and FLUXSTD separately. Comparing the sums would let a
-        # deficit in one target type be cancelled out by a surplus in the other.
-        mismatches: list[str] = []
-        if n_fiber_work_science != n_fiber_unmasked_science:
-            mismatches.append(
-                f"Number of SCIENCE fibers for {propid_work} ({n_fiber_work_science}) does not "
-                f"match the number of unmasked SCIENCE fibers ({n_fiber_unmasked_science})."
-            )
-        if n_fiber_work_fluxstd != n_fiber_unmasked_fluxstd:
-            mismatches.append(
-                f"Number of FLUXSTD fibers for {propid_work} ({n_fiber_work_fluxstd}) does not "
-                f"match the number of unmasked FLUXSTD fibers ({n_fiber_unmasked_fluxstd})."
-            )
-        if mismatches:
-            message = " ".join(mismatches)
-            logger.error(f"  {message}")
-            raise ValueError(message)
+        # NOTE: this used to compare the number of fibers belonging to this
+        # proposal with the number left unmasked. Both were counted from the same
+        # condition, so they agreed by construction and the check could not fail.
+        # The redacted config is inspected instead.
+        _verify_redaction(
+            pfs_config,
+            redacted_cfg,
+            propid_work,
+            dict_mask_science,
+            dict_mask_fluxstd,
+            flux_keys,
+            flux_val,
+            filter_val,
+        )
 
         redacted_pfsconfigs.append(
             RedactedPfsConfigDataClass(proposal_id=propid_work, pfs_config=redacted_cfg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,20 +151,10 @@ def mock_pfs_config():
     mock_config.totalFluxErr = mock_config.totalFlux * 0.1
 
     # Filter information
-    mock_config.filterNames = np.array(
-        [
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-            ["g", "r", "i", "z", "y"],
-        ]
-    )
+    # NOTE: a list of lists, as the datamodel defines it. A numpy array would
+    # be fixed width, and assigning the mask value "none" into a <U1 array
+    # truncates it to "n".
+    mock_config.filterNames = [["g", "r", "i", "z", "y"] for _ in range(10)]
 
     return mock_config
 
@@ -215,7 +205,7 @@ def simple_mock_pfs_config():
         elif "Flux" in attr:
             setattr(mock_config, attr, np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]))
         elif attr == "filterNames":
-            setattr(mock_config, attr, np.array([["g", "r"], ["i", "z"], ["g", "i"]]))
+            setattr(mock_config, attr, [["g", "r"], ["i", "z"], ["g", "i"]])
         else:
             setattr(mock_config, attr, np.array([1.0, 2.0, 3.0]))
 
@@ -289,7 +279,7 @@ def mock_pfs_config_dup_fluxstd():
     mock_config.psfFluxErr = mock_config.psfFlux * 0.1
     mock_config.totalFluxErr = mock_config.totalFlux * 0.1
 
-    mock_config.filterNames = np.array([["g", "r", "i"]] * n_fiber)
+    mock_config.filterNames = [["g", "r", "i"] for _ in range(n_fiber)]
 
     return mock_config
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -73,7 +73,7 @@ class TestEdgeCases:
             elif "Flux" in attr:
                 setattr(mock_config, attr, np.array([[1.0, 2.0]]))
             elif attr == "filterNames":
-                setattr(mock_config, attr, np.array([["g", "r"]]))
+                setattr(mock_config, attr, [["g", "r"]])
             else:
                 setattr(mock_config, attr, np.array([1.0]))
 
@@ -165,7 +165,7 @@ class TestEdgeCases:
                 setattr(
                     mock_config,
                     attr,
-                    np.array([["g", "r"], ["i", "z"], ["g", "i"], ["r", "z"]]),
+                    [["g", "r"], ["i", "z"], ["g", "i"], ["r", "z"]],
                 )
             else:
                 setattr(mock_config, attr, np.array([1.0, 2.0, 3.0, 4.0]))
@@ -222,7 +222,7 @@ class TestEdgeCases:
             elif "Flux" in attr:
                 setattr(mock_config, attr, np.array([[1.0, 2.0]]))
             elif attr == "filterNames":
-                setattr(mock_config, attr, np.array([["g", "r"]]))
+                setattr(mock_config, attr, [["g", "r"]])
             else:
                 setattr(mock_config, attr, np.array([1.0]))
 
@@ -296,7 +296,7 @@ class TestEdgeCases:
             elif "Flux" in attr:
                 setattr(mock_config, attr, np.array([[1.0, 2.0], [3.0, 4.0]]))
             elif attr == "filterNames":
-                setattr(mock_config, attr, np.array([["g", "r"], ["i", "z"]]))
+                setattr(mock_config, attr, [["g", "r"], ["i", "z"]])
             else:
                 setattr(mock_config, attr, np.array([1.0, 2.0]))
 
@@ -348,7 +348,7 @@ class TestEdgeCases:
             elif "Flux" in attr and attr != "fiberFlux":
                 setattr(mock_config, attr, np.array([[1.0, 2.0], [3.0, 4.0]]))
             elif attr == "filterNames":
-                setattr(mock_config, attr, np.array([["g", "r"], ["i", "z"]]))
+                setattr(mock_config, attr, [["g", "r"], ["i", "z"]])
             else:
                 setattr(mock_config, attr, np.array([1.0, 2.0]))
 
@@ -396,7 +396,7 @@ class TestEdgeCases:
         mock_config.objId = np.array([10])
 
         # Empty filter names
-        mock_config.filterNames = np.array([[]])
+        mock_config.filterNames = [[]]
 
         # Add other required attributes
         for attr in [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -159,6 +159,27 @@ class TestIntegration:
         assert len(results) == 1
         assert results[0].pfs_config.targetType[i] == TargetType.SUNSS_IMAGING
 
+    def test_mask_leaving_the_proposal_association_is_refused(self, drp_pfs_config):
+        """A mask that would deliver another proposal's association is refused.
+
+        The result is checked against the input before it is returned, so a mask
+        dictionary that forgets proposalId cannot produce a file no matter what
+        else it masks.
+        """
+        with pytest.raises(ValueError, match="proposalId"):
+            pfsconfig_redaction.redact(
+                drp_pfs_config,
+                dict_mask_science={"ra": -99, "dec": -99},
+            )
+
+    def test_mask_leaving_the_ob_code_is_refused(self, drp_pfs_config):
+        """obCode identifies the observing block of the other proposal too."""
+        with pytest.raises(ValueError, match="obCode"):
+            pfsconfig_redaction.redact(
+                drp_pfs_config,
+                dict_mask_science={"proposalId": "masked", "ra": -99},
+            )
+
     def test_mask_value_wider_than_the_column_is_not_truncated(self, drp_pfs_config):
         """A mask value longer than the FITS column survives intact.
 
@@ -177,6 +198,7 @@ class TestIntegration:
             original,
             dict_mask_science={
                 "patch": "-1,-1",
+                "proposalId": "masked",
                 "obCode": long_ob_code,
                 "targetType": TargetType.SCIENCE_MASKED,
             },
@@ -207,6 +229,7 @@ class TestIntegration:
             "ra": -88.0,
             "dec": -88.0,
             "proposalId": "CUSTOM_MAS",  # 10 characters: the column width
+            "obCode": "CUSTOM_MASKED",
         }
         custom_flux_val = -999.0
         custom_filter_val = "MASKED"

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -108,7 +108,7 @@ class TestLargeInputs:
 
         # Filter names
         filter_names = ["g", "r", "i", "z", "y"]
-        mock_config.filterNames = np.array([filter_names for _ in range(n_fibers)])
+        mock_config.filterNames = [list(filter_names) for _ in range(n_fibers)]
 
         return mock_config
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,9 +89,13 @@ class TestRedactFunction:
         )
 
         # Add filter attributes
-        mock_config.filterNames = np.array(
-            [["g", "r"], ["r", "i"], ["i", "z"], ["z", "y"], ["g", "i"]]
-        )
+        mock_config.filterNames = [
+            ["g", "r"],
+            ["r", "i"],
+            ["i", "z"],
+            ["z", "y"],
+            ["g", "i"],
+        ]
 
         return mock_config
 
@@ -108,12 +112,17 @@ class TestRedactFunction:
         assert "S25A-002QF" in proposal_ids
         assert "N/A" not in proposal_ids
 
-    @patch("pfsconfig_redaction.utils.copy.deepcopy")
-    def test_redact_custom_parameters(self, mock_deepcopy, mock_pfs_config):
+    def test_redact_custom_parameters(self, mock_pfs_config):
         """Test redact function with custom parameters."""
-        mock_deepcopy.return_value = mock_pfs_config
-
-        custom_dict_mask = {"catId": 8000, "ra": -88, "dec": -88}
+        # NOTE: proposalId and obCode have to be in any mask dictionary; redact()
+        # refuses to hand out a config that still carries them.
+        custom_dict_mask = {
+            "catId": 8000,
+            "ra": -88,
+            "dec": -88,
+            "proposalId": "masked",
+            "obCode": "masked",
+        }
         custom_flux_keys = ["fiberFlux", "psfFlux"]
         custom_flux_val = -999.0
         custom_filter_val = "masked"
@@ -140,8 +149,13 @@ class TestRedactFunction:
         assert isinstance(result, list)
         assert len(result) == 0  # No valid proposal IDs to process
 
-    def test_redact_fiber_count_validation(self, mock_pfs_config):
-        """Test that fiber count validation works correctly."""
+    def test_masking_that_misses_a_fiber_is_caught(self, mock_pfs_config):
+        """A fiber that should have been masked but was not stops the redaction.
+
+        The working copy is corrupted so that the masking loop does not recognise
+        the fiber as belonging to another proposal and skips it. The verification
+        derives what had to be masked from the original config, so it notices.
+        """
         # Create a corrupted copy where targetType gets modified during deepcopy
         # to simulate a scenario where counts don't match
         corrupted_template = Mock(spec=PfsConfig)
@@ -200,7 +214,7 @@ class TestRedactFunction:
                 "pfsconfig_redaction.utils.copy.deepcopy",
                 side_effect=lambda _: real_deepcopy(corrupted_template),
             ),
-            pytest.raises(ValueError, match="Number of SCIENCE fibers"),
+            pytest.raises(ValueError, match="ra was not masked"),
         ):
             redact(mock_pfs_config)
 
@@ -312,8 +326,8 @@ class TestFluxstdRedaction:
         assert redacted.proposalId[self.IDX_DUP_FLUXSTD] == "REDACTED"
         assert redacted.obCode[self.IDX_DUP_FLUXSTD] == "REDACTED"
 
-    def test_fluxstd_count_mismatch_raises(self, mock_pfs_config_dup_fluxstd):
-        """A FLUXSTD count mismatch is caught on its own, not hidden by the SCIENCE count."""
+    def test_masking_that_misses_a_fluxstd_is_caught(self, mock_pfs_config_dup_fluxstd):
+        """A FLUXSTD is checked on its own, not folded into the SCIENCE fibers."""
         original = mock_pfs_config_dup_fluxstd
 
         # Corrupt the working copy so the owner's duplicated FLUXSTD is no longer
@@ -339,7 +353,7 @@ class TestFluxstdRedaction:
                 "pfsconfig_redaction.utils.copy.deepcopy",
                 side_effect=lambda _: real_deepcopy(corrupted_template),
             ),
-            pytest.raises(ValueError, match="Number of FLUXSTD fibers"),
+            pytest.raises(ValueError, match="obCode was not masked"),
         ):
             redact(original)
 


### PR DESCRIPTION
## Problem

The consistency check compared the number of fibers belonging to the proposal being processed with the number left unmasked:

```python
if n_fiber_work_science != n_fiber_unmasked_science:
    raise ValueError(...)
```

Both were counted from the same condition. A fiber whose `proposalId` equals the recipient's can never be "of another proposal", so it always landed in the branch the second counter counted. **The two numbers agreed by construction and the check could not fail.** It only ever fired in tests that stood in for `copy.deepcopy` with a deliberately corrupted object.

That is worse than no check, because it reads like assurance.

## Fix

The redacted config is read back and checked against the input before it is returned. Which fibers had to be masked is derived from the *original*, so the check does not restate the masking rules and cannot agree with the loop by construction:

1. **every fiber that had to be masked holds the mask values** — catches a value that failed to be stored;
2. **no fiber of another proposal still shows its original `proposalId` or `obCode`** — holds whatever the mask values happen to be, so a custom mask dictionary that forgets either one is refused;
3. **the fibers that had to be left alone are untouched** — redaction cannot quietly damage the recipient's own targets or the sky fibers.

Failure is fail-closed, consistent with #34: nothing is returned.

## Evidence each check is live

Check 2 has direct tests through the public API (`test_mask_leaving_the_proposal_association_is_refused`, `test_mask_leaving_the_ob_code_is_refused`), which fail with `DID NOT RAISE ValueError` before the change.

Checks 1 and 3 can only fire if the masking loop is broken, so they were verified by mutation:

| Mutation | Reported |
|---|---|
| disable the column widening from #33 | `patch was not masked with '-1,-1' on all 6 fibers that required it` |
| touch a fiber that must be left alone | `ra was modified on fibers that had to be left alone` |

The first is worth noting: **this check would have caught the truncation bug of #33 on its own.**

## Two false positives found while writing it

Both would have hit real files, and both are covered by existing tests:

- an `obCode` that was already `"N/A"` does not "survive" masking — masking it leaves it unchanged, and it identifies nothing;
- a `NaN` that was in the input is not a modification (`np.array_equal` needs `equal_nan` for the untouched-fiber comparison).

## Test changes this forced

- The two tests that fed a corrupted copy through `copy.deepcopy` asserted on the count check that no longer exists. They now assert on the new one — the scenario they build (a fiber that should have been masked and was not) is exactly what check 1 catches.
- `test_redact_custom_parameters` stops mocking `deepcopy`; with the mock, the "copy" was the input itself, so check 2 saw `before is after`. This was the last of those mocks.
- Custom mask dictionaries in tests gained the `proposalId`/`obCode` entries check 2 requires. This is a deliberate API tightening: a caller-supplied mask that leaves the proposal association is now an error.
- **The mock fixtures stop building `filterNames` as a numpy array.** The datamodel defines it as a `list` of `list` of `str`, and a real file reads back as one; a `<U1` numpy array silently truncated the `"none"` mask value to `"n"`. Check 1 reported this on 34 test cases — the mocks had been wrong, and nothing had noticed.

## Cost

```
2458 fibers, 5 proposals: 0.13 s -> 0.33 s
```

The test suite goes from ~17 s to ~36 s, almost all of it in the two synthetic 5000/10000-fiber tests.

```console
$ uv run pytest -q
53 passed
$ uv run ruff check src tests && uv run ruff format --check src tests
All checks passed!
10 files already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)