### PR TITLE
Let the lint and format checks fail the build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,13 +32,7 @@ jobs:
       run: uv run pytest tests/ -v --tb=short
     
     - name: Run linting with ruff
-      run: uv run ruff check src/
-      continue-on-error: true
-    
+      run: uv run ruff check src/ tests/
+
     - name: Run code formatting check
-      run: |
-        echo "Checking code formatting..."
-        if ! uv run ruff format --check src/; then
-          echo "Code formatting issues found. Consider running 'uv run ruff format src/' to fix them."
-        fi
-      continue-on-error: true
+      run: uv run ruff format --check src/ tests/


### PR DESCRIPTION
## Problem

Both quality steps carried `continue-on-error: true`, so ruff could report anything at all and the workflow still went green. The formatting step was neutered twice over:

```yaml
- name: Run code formatting check
  run: |
    echo "Checking code formatting..."
    if ! uv run ruff format --check src/; then
      echo "Code formatting issues found. Consider running 'uv run ruff format src/' to fix them."
    fi
  continue-on-error: true
```

The `if ! ...; then echo ...; fi` wrapper exits 0 whatever ruff says, and `continue-on-error` then covered even that. The checks were decoration.

## Change

Drop both, and check `tests/` as well as `src/`. Both are clean as of now, so this is the moment to switch the gate on.

## Verification

The point of this PR is that a declared check was not gating, so "the gate is on now" needed showing rather than asserting. A commit introducing a deliberate `I001`/`F401` in `tests/test_import.py` was pushed to this branch first, and then removed.

**With the violation** ([run 31375821247](https://github.com/Subaru-SciOp/pfsconfig_redaction/actions/runs/31375821247)) — the tests passed and the build went red anyway, which is exactly the behaviour that was missing:

```
test (3.12)  Run tests                ======= 53 passed, 3 warnings in 35.00s =======
test (3.12)  Run linting with ruff    I001 [*] Import block is un-sorted or un-formatted
                                       --> tests/test_import.py:1:1
test (3.12)  Run linting with ruff    ##[error]Process completed with exit code 1.

test (3.12): failure    test (3.11): cancelled    test (3.13): cancelled
```

**After removing it** ([run 31376004833](https://github.com/Subaru-SciOp/pfsconfig_redaction/actions/runs/31376004833)):

```
test (3.11)  pass  1m29s
test (3.12)  pass  1m10s
test (3.13)  pass  1m13s
```

## Note

Unrelated to this change, but worth knowing: the workflow only runs on `pull_request`, and on `push` to `main`. Pushing a feature branch triggers nothing, so CI results only appear once a PR exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)