### PR TITLE
Stop configuring logging on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,19 @@ pip install .
 ## Usage
 
 ```python
+import logging
 from pathlib import Path
 
 from pfs.datamodel import PfsConfig
 import pfsconfig_redaction
+
+# The package logs what it masks, per fiber type and per proposal, but it does
+# not configure logging itself: where records go is the application's decision.
+# This line is what makes those messages appear in a script.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 
 indir = Path("tmp")
 outdir = Path("tmp")

--- a/src/pfsconfig_redaction/utils.py
+++ b/src/pfsconfig_redaction/utils.py
@@ -6,13 +6,11 @@ from pprint import pformat
 import numpy as np
 from pfs.datamodel import PfsConfig, TargetType
 
-# Basic configuration
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
-
-# Get a logger for your module
+# NOTE: no logging.basicConfig() here. Calling it at import time would set the
+# level and install a handler on the root logger of whatever imports this
+# package, overriding the application's own configuration. Deciding where log
+# records go belongs to the application; see the README for a one-liner that
+# turns these messages on in a script.
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 import pytest
 
 
@@ -72,6 +76,38 @@ class TestImports:
             assert Mock is not None
         except ImportError:
             pytest.fail("unittest.mock is not available")
+
+    def test_importing_does_not_configure_the_root_logger(self):
+        """Importing the package leaves the application's logging alone.
+
+        A library that calls logging.basicConfig() sets the level and installs a
+        handler on the root logger of whatever imports it, silently overriding
+        the application's own configuration.
+
+        NOTE: run in a subprocess, because the package is already imported by
+        the time this test runs and the effect only happens once.
+        """
+        script = textwrap.dedent(
+            """
+            import logging
+
+            before = (logging.root.level, len(logging.root.handlers))
+            import pfsconfig_redaction  # noqa: F401
+            after = (logging.root.level, len(logging.root.handlers))
+
+            print(before, "->", after)
+            """
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        before, after = result.stdout.strip().split(" -> ")
+        assert before == after, f"importing changed the root logger: {result.stdout}"
 
     def test_logging_setup(self):
         """Test that logging is properly configured."""


### PR DESCRIPTION
## Problem

`utils.py` called `logging.basicConfig()` at import time:

```python
logging.basicConfig(
    level=logging.INFO,
    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
)
```

That sets the level and installs a handler on the **root** logger of whatever imports the package:

```console
$ python -c "import logging; b=(logging.root.level, len(logging.root.handlers)); \
    import pfsconfig_redaction; print(b, '->', (logging.root.level, len(logging.root.handlers)))"
(30, 0) -> (20, 1)
```

An application that had configured its own logging found it overridden by an import; one that had deliberately stayed quiet started emitting records at INFO. Deciding where log records go belongs to the application, not to a library it imports.

## Change

Drop the call. The package keeps its module logger and logs exactly as before — the records simply go wherever the application has decided, and nowhere if it has decided nothing.

## This changes what a script sees

Anyone following the README got the log output for free. They now need one line, so the README example carries it explicitly:

```python
logging.basicConfig(
    level=logging.INFO,
    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
)
```

Verified against the sample file:

| | |
|---|---|
| README example, with the line | 40 INFO records, `RESULT: 3 redacted configs` |
| same script without it | no log output, `RESULT: 3 redacted configs` |

## Tests

Test-first. `test_importing_does_not_configure_the_root_logger` compares the root logger's level and handler count across the import. RED:

```console
E  AssertionError: importing changed the root logger: (30, 0) -> (20, 1)
```

It runs in a subprocess, because the package is already imported by the time the suite runs and the effect only happens once.

```console
$ uv run pytest -q
54 passed
$ uv run ruff check src tests && uv run ruff format --check src tests
All checks passed!
10 files already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)