### PR TITLE
Add a scheduled run against the latest dependencies

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,54 @@
+name: Upstream
+
+# pfs-datamodel is a git dependency that is deliberately not pinned: deliveries
+# use whatever is current. uv.lock does pin it, so the Tests workflow answers
+# "does the code work against the versions we recorded", not "does it still work
+# against what a delivery will actually install".
+#
+# This workflow answers the second question. It resolves everything afresh with
+# --upgrade, so a breaking change upstream shows up here rather than in the
+# middle of preparing a delivery.
+on:
+  schedule:
+    # Mondays, 21:00 UTC (Tuesday 06:00 JST), so a failure is waiting at the
+    # start of the week rather than arriving mid-delivery.
+    - cron: "0 21 * * 1"
+  # Run it by hand before a delivery, from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  test-against-latest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v9.0.0
+      with:
+        version: "latest"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+
+    - name: Install the latest of every dependency
+      run: uv sync --dev --upgrade
+
+    - name: Report what was resolved
+      run: |
+        echo "pfs-datamodel resolved to:"
+        # NOTE: the name appears three times in the lock, twice as a dependency
+        # of something else. Only the package block carries a git source.
+        grep -A2 'name = "pfs-datamodel"' uv.lock | grep 'source = { git'
+
+    - name: Run tests
+      run: uv run pytest tests/ -v --tb=short
+
+    # NOTE: the refreshed uv.lock is deliberately not committed. This workflow
+    # reports on the latest versions; deciding to move to them is a separate act,
+    # done with "uv sync --upgrade" locally and reviewed as a normal change.


### PR DESCRIPTION
Follow-up to the dependency discussion: `pfs-datamodel` stays unpinned, so this adds the check that makes that policy safe.

## Why

`uv.lock` pins `pfs-datamodel` to a commit, and the Tests workflow runs `uv sync --dev`, which respects the lock. So CI answers *"does the code work against the versions we recorded"* — not *"does it still work against what a delivery will actually install"*. With the deliberate policy of always using the current upstream, a breaking change would first be noticed while preparing a delivery.

## What it does

A separate `Upstream` workflow that resolves everything afresh (`uv sync --dev --upgrade`) and runs the suite:

- **weekly**, Mondays 21:00 UTC (Tuesday 06:00 JST), so a failure is waiting at the start of the week rather than arriving mid-delivery;
- **on demand** via `workflow_dispatch` — this is the useful one, runnable from the Actions tab before a delivery.

It prints which `pfs-datamodel` commit was resolved, and **does not commit the refreshed lock**: reporting on newer versions and moving to them stay separate acts. `fail-fast: false`, so one Python version breaking does not hide the others.

The main Tests workflow is untouched, so an upstream break does not turn unrelated PRs red.

## State at the time of writing

This would pass and change nothing today:

```console
$ gh api repos/Subaru-PFS/datamodel/commits/master --jq .sha
1e83ab520cdc40dbf2173672a8cd4085537bcb6f     # what uv.lock already pins

$ uv sync --upgrade && git diff --stat uv.lock
                                             # no diff: everything already latest
$ uv run pytest -q
54 passed
```

So the canary is being added while it is quiet, which is the right time.

## Verification limits

`workflow_dispatch` and `schedule` only fire for workflows on the default branch, so **this cannot run until it is merged**. What was checked instead:

- both workflow files parse, and the step lists are as intended;
- `uv sync --dev --upgrade` followed by the suite works locally (54 passed);
- the reporting `grep` was checked against the real lock. The naive form is wrong — `name = "pfs-datamodel"` appears three times, twice as a dependency of something else, and `-A1 | grep source` picks up a `scipy` line. The workflow uses the form that selects the package block's git source.

Worth a manual run from the Actions tab after merging, to confirm end to end.

## Note

GitHub disables scheduled workflows in a repository with no activity for 60 days; they can be re-enabled from the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)